### PR TITLE
readVcfGT: split non-biallelic records rather then skipping

### DIFF
--- a/test/read.vcf
+++ b/test/read.vcf
@@ -1,0 +1,40 @@
+##fileformat=VCFv4.1
+##FILTER=<ID=PASS,Description="All filters passed">
+##reference=file:///seq/references/1000Genomes-NCBI37.fasta
+##contig=<ID=X,length=155270560>
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Raw read depth">
+##INFO=<ID=DP4,Number=4,Type=Integer,Description="# high-quality ref-forward bases, ref-reverse, alt-forward and alt-reverse bases">
+##INFO=<ID=Dels,Number=1,Type=Float,Description="Fraction of reads containing spanning deletions">
+##INFO=<ID=FS,Number=1,Type=Float,Description="Phred-scaled p-value using Fisher's exact test to detect strand bias">
+##INFO=<ID=HRun,Number=1,Type=Integer,Description="Largest contiguous homopolymer run of variant allele in either direction">
+##INFO=<ID=HWE,Number=1,Type=Float,Description="Hardy-Weinberg equilibrium test (PMID:15789306)">
+##INFO=<ID=ICF,Number=1,Type=Float,Description="Inbreeding coefficient F">
+##INFO=<ID=INDEL,Number=0,Type=Flag,Description="Indicates that the variant is an INDEL.">
+##INFO=<ID=IS,Number=2,Type=Float,Description="Maximum number of reads supporting an indel and fraction of indel reads">
+##INFO=<ID=MQ,Number=1,Type=Integer,Description="Root-mean-square mapping quality of covering reads">
+##INFO=<ID=MQ0,Number=1,Type=Integer,Description="Total mapping quality zero reads">
+##INFO=<ID=PV4,Number=4,Type=Float,Description="P-values for strand bias, baseQ bias, mapQ bias and tail distance bias">
+##INFO=<ID=QD,Number=1,Type=Float,Description="Variant confidence/quality by depth">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="# high-quality bases">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=PL,Number=G,Type=Integer,Description="List of Phred-scaled genotype likelihoods">
+##FILTER=<ID=StrandBias,Description="Min P-value for strand bias (INFO/PV4) [0.0001]">
+##FILTER=<ID=BaseQualBias,Description="Min P-value for baseQ bias (INFO/PV4) [1e-100]">
+##FILTER=<ID=MapQualBias,Description="Min P-value for mapQ bias (INFO/PV4) [0]">
+##FILTER=<ID=EndDistBias,Description="Min P-value for end distance bias (INFO/PV4) [0.0001]">
+##FILTER=<ID=MinAB,Description="Minimum number of alternate bases (INFO/DP4) [2]">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+X	76962	.	T	C	999	PASS	DP4=110138,70822,421911,262673;DP=911531;Dels=0;FS=21.447;HWE=0.491006;ICF=-0.01062;MQ0=1;MQ=46;PV4=2.5e-09,0,0,1;QD=22.31	GT:PL:DP:GQ	0/1:255,0,255:193:99	1/1:255,255,0:211:99	1/1:255,255,0:182:99
+X	126310	.	ACC	A	999	StrandBias;EndDistBias	DP4=125718,95950,113812,80890;DP=461867;HWE=0.24036;ICF=0.01738;INDEL;IS=374,0.937343;MQ=49;PV4=9e-30,1,0,3.8e-13;QD=0.0172;AN=6;AC=4	GT:DP:GQ:PL	0/1:117:99:255,0,132	0/1:111:99:255,0,139	1/1:78:99:255,213,0
+X	138125	.	G	T	999	PASS	DP4=174391,20849,82080,4950;DP=286107;Dels=0;FS=3200;HWE=0.199462;ICF=0.01858;MQ0=0;MQ=46;PV4=0,0,0,1;QD=17.22;AN=6;AC=4	GT:PL:DP:GQ	0/1:135,0,163:66:99	0/1:140,0,255:71:99	1/1:255,199,0:66:99
+X	138148	.	C	T	999	PASS	DP4=194136,45753,94945,14367;DP=356657;Dels=0;FS=3200;HWE=0.177865;ICF=0.0198;MQ0=0;MQ=47;PV4=0,0,0,1;QD=14.57;AN=6;AC=4	GT:PL:DP:GQ	0/1:195,0,255:87:99	0/1:192,0,255:82:99	1/1:255,235,0:78:99
+X	271225	.	T	TTTA,TA	999	StrandBias	DP4=29281,42401,27887,29245;DP=272732;INDEL;IS=95,0.748031;MQ=47;PV4=0,1,0,1;QD=0.0948;AN=6;AC=2,2	GT:DP:GQ:PL	0/2:33:49:151,53,203,0,52,159	0/1:51:99:255,0,213,255,255,255	1/2:47:99:255,255,255,255,0,241
+X	304568	.	C	T	999	PASS	DP4=16413,4543,945,156;DP=43557;Dels=0;FS=3200;HWE=0.076855;ICF=0.0213;MQ0=0;MQ=50;PV4=0,0,0,1;QD=15.45;AN=6;AC=4	GT:PL:DP:GQ	0|1:95,0,255:90:99	0|1:192,0,255:13:99	1|1:255,95,0:60:99
+X	326891	.	A	AC	999	PASS	DP4=125718,95950,113812,80890;DP=461867;HWE=0.24036;ICF=0.01738;INDEL;IS=374,0.937343;MQ=49;PV4=9e-30,1,0,3.8e-13;QD=0.0172;AN=4;AC=2	GT:DP:GQ:PL	0|1:117:99:255,0,132	0|1:111:99:255,0,139	./.:.:.:.,.,.
+X	2928329	.	C	T	999	PASS	DP4=302,9137,32,1329;DP=11020;Dels=0;FS=13.38;HWE=0.284332;ICF=0.0253;MQ0=0;MQ=49;PV4=0.094,0,0,1;QD=18.61;AN=4;AC=1	GT:PL:DP:GQ	0:0,56:2:73	0:0,81:3:98	0/1:73,0,19:4:30
+X	2933066	.	G	C	999	PASS	DP4=69865,100561,461,783;DP=173729;Dels=0;FS=10.833;MQ0=0;MQ=50;PV4=0.005,3.6e-14,0,1;QD=15.33;AN=3;AC=1	GT:PL:DP:GQ	.:0,255:39:99	0:0,255:37:99	0/1:255,255,255:62:99
+X	2942109	.	T	C	999	PASS	DP4=23273,27816,40128,48208;DP=146673;Dels=0;FS=43.639;HWE=0.622715;ICF=-0.01176;MQ0=1;MQ=46;PV4=0.65,1,0,1;QD=14.81;AN=4;AC=3	GT:PL:DP:GQ	0:0,255:20:99	1:255,0:33:99	1/1:255,157,0:52:99
+X	3048719	.	T	C	999	PASS	DP4=13263,27466,40128,48208;DP=146673;Dels=0;FS=43.639;HWE=0.622715;ICF=-0.01176;MQ0=1;MQ=46;PV4=0.65,1,0,1;QD=14.81;AN=4;AC=3	GT:PL:DP:GQ	0:0,255:20:99	1:255,0:33:99	0|1:255,0,157:52:99

--- a/test/test.pl
+++ b/test/test.pl
@@ -13,6 +13,7 @@ my $opts = parse_params();
 test_pbwt($opts, in=>'merge.1', out=>'merge.1.out');
 test_pbwt($opts, in=>'merge.2', out=>'merge.2.out');
 test_write_vcf($opts, in=>'merge.1', out=>'merge.1.vcf');
+test_read_vcf_gt($opts, in=>'read.vcf', out=>'write.vcf');
 test_merge($opts,in=>['merge.1','merge.2'],out=>'merge.12.out');
 test_merge_sites($opts,in=>['merge.1','merge.2'],out=>'merge.12.sites');
 
@@ -185,6 +186,12 @@ sub test_write_vcf
 {
     my ($opts,%args) = @_;
     test_cmd($opts,%args,cmd=>"$$opts{bin}/pbwt -read $$opts{tmp}/$args{in}.pbwt -readSites $$opts{tmp}/$args{in}.sites -writeVcf - 2>/dev/null | grep -v ^##pbwtVersion >$$opts{tmp}/$args{out}");
+}
+
+sub test_read_vcf_gt
+{
+    my ($opts,%args) = @_;
+    test_cmd($opts,%args,cmd=>"$$opts{bin}/pbwt -readVcfGT $$opts{path}/read.vcf -writeVcf - 2>/dev/null | grep -v ^##pbwtVersion >$$opts{tmp}/$args{out}");
 }
 
 sub test_merge

--- a/test/write.vcf
+++ b/test/write.vcf
@@ -1,0 +1,18 @@
+##fileformat=VCFv4.2
+##FILTER=<ID=PASS,Description="All filters passed">
+##INFO=<ID=AC,Number=A,Type=Integer,Description="Allele count in genotypes">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+X	76962	.	T	C	.	PASS	AC=5;AN=6	GT	0|1	1|1	1|1
+X	126310	.	ACC	A	.	PASS	AC=4;AN=6	GT	0|1	0|1	1|1
+X	138125	.	G	T	.	PASS	AC=4;AN=6	GT	0|1	0|1	1|1
+X	138148	.	C	T	.	PASS	AC=4;AN=6	GT	0|1	0|1	1|1
+X	271225	.	T	TTTA	.	PASS	AC=2;AN=6	GT	0|0	0|1	1|0
+X	271225	.	T	TA	.	PASS	AC=2;AN=6	GT	0|1	0|0	0|1
+X	304568	.	C	T	.	PASS	AC=4;AN=6	GT	0|1	0|1	1|1
+X	326891	.	A	AC	.	PASS	AC=2;AN=6	GT	0|1	0|1	0|0
+X	2928329	.	C	T	.	PASS	AC=1;AN=6	GT	0|0	0|0	0|1
+X	2933066	.	G	C	.	PASS	AC=1;AN=6	GT	0|0	0|0	0|1
+X	2942109	.	T	C	.	PASS	AC=3;AN=6	GT	0|0	1|0	1|1
+X	3048719	.	T	C	.	PASS	AC=2;AN=6	GT	0|0	1|0	0|1


### PR DESCRIPTION
- Split non-biallelic records into biallelic records, filling in REF for "unseen" alleles
  
  ```
  T   A,C 0|0 0|1 1|0 1|1 1|2 0|2 2|0 2|1 2|2
  ```
  
  becomes
  
  ```
  T   A   0|0 0|1 1|0 1|1 1|0 0|0 0|0 0|1 0|0
  T   C   0|0 0|0 0|0 0|0 0|1 0|1 1|0 1|0 1|1
  ```
- add test for reading and writing a VCF
- treat haploid genotypes in the non-PAR region as diploid A/A
- convert tabs to spaces
