### PR TITLE
Added -writePhase and fixed a bug in the locations read by -readPhase

### DIFF
--- a/pbwt.h
+++ b/pbwt.h
@@ -172,6 +172,7 @@ void pbwtWriteDosage (PBWT *p, FILE *fp) ;
 void pbwtWriteReverse (PBWT *p, FILE *fp) ;
 void pbwtWriteAll (PBWT *p, char *fileNameRoot) ;
 void pbwtWriteGen (PBWT *p, FILE *fp) ; /* write gen file as for impute etc. */
+void pbwtWritePhase (PBWT *p, char *filename); /* Write phase file as output by impute and input for chromopainter */
 PBWT *pbwtRead (FILE *fp) ;
 Array pbwtReadSitesFile (FILE *fp, char **chrom) ;
 void pbwtReadSites (PBWT *p, FILE *fp) ;
@@ -189,6 +190,7 @@ PBWT *pbwtReadHap (FILE *fp, char *chrom) ;	/* hap file as used by impute2 (unph
 PBWT *pbwtReadHapLegend (FILE *fp, FILE *lp, char *chrom) ; /* hap and legend file as used by impute2 (phased) */
 PBWT *pbwtReadPhase (FILE *fp) ; /* Li and Stephens PHASE file */
 void pbwtWriteHaplotypes (FILE *fp, PBWT *p) ;
+void pbwtWriteTransposedHaplotypes (FILE *fp, PBWT *p) ;
 void pbwtWriteImputeRef (PBWT *p, char *fileNameRoot) ;
 void pbwtWriteImputeHapsG (PBWT *p, FILE *fp) ;
 void pbwtCheckPoint (PbwtCursor *u, PBWT *p) ; /* need cursor to write end index */

--- a/pbwtMain.c
+++ b/pbwtMain.c
@@ -15,7 +15,7 @@
  * Description:
  * Exported functions:
  * HISTORY:
- * Last edited: Aug  7 16:20 2015 (rd)
+ * Last edited: Sept 30 19:44 2015 (djl)
  * paintSparse added
  * Created: Thu Apr  4 12:05:20 2013 (rd)
  *-------------------------------------------------------------------
@@ -173,7 +173,7 @@ static void recordCommandLine (int argc, char *argv[])
 
 const char *pbwtCommitHash(void)
 {
-    return PBWT_COMMIT_HASH ;
+  return PBWT_COMMIT_HASH ;
 }
 
 FILE *logFile ; /* log file pointer */
@@ -230,6 +230,7 @@ int main (int argc, char *argv[])
       fprintf (stderr, "  -writeAll <rootname>      write .pbwt and if present .sites, .samples, .missing, .dosage\n") ;
       fprintf (stderr, "  -writeImputeRef <rootname> write .imputeHaps and .imputeLegend\n") ;
       fprintf (stderr, "  -writeImputeHapsG <file>  write haplotype file for IMPUTE -known_haps_g\n") ;
+      fprintf (stderr, "  -writePhase <file>        write FineSTRUUCTURE/ChromoPainter input format (Impute/ShapeIT output format) phase file\n") ;
       fprintf (stderr, "  -haps <file>              write haplotype file; '-' for stdout\n") ;
       fprintf (stderr, "  -writeGen <file>          write impute2 gen file; '-' for stdout\n") ;
       fprintf (stderr, "  -writeVcf|-writeVcfGz|-writeBcf|-writeBcfGz <file>\n") ;
@@ -344,6 +345,8 @@ int main (int argc, char *argv[])
       { FOPEN("writeImputeHaps","w") ; pbwtWriteImputeHapsG (p, fp) ; FCLOSE ; argc -= 2 ; argv += 2 ; }
     else if (!strcmp (argv[0], "-writeGen") && argc > 1)
       { FOPEN("writeGen","w") ; pbwtWriteGen (p, fp) ; FCLOSE ; argc -= 2 ; argv += 2 ; }
+    else if (!strcmp (argv[0], "-writePhase") && argc > 1)
+      { pbwtWritePhase (p,argv[1]) ; argc -= 2 ; argv += 2 ; }
     else if (!strcmp (argv[0], "-referenceFasta") && argc > 1)
       { referenceFasta = strdup(argv[1]) ; argc -= 2 ; argv += 2 ; }
     else if (!strcmp (argv[0], "-writeVcf") && argc > 1)


### PR DESCRIPTION
-writePhase is useful to be able to run ChromoPainter on pre-existing PBWT files. Also, -readPhase was not quite correct for v2 files. This should make both of these work properly.

The writeTransposedHaplotypes is implemented naively, but this should be OK as any Phase file that can be used, can also be written and read. Multiple passes appear to be necessary to transpose without creating the whole L by N data matrix in memory.