### PR TITLE
Fixed -writeTransposedHaplotypes and -writePhase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
-
 CFLAGS= -g -O3
 CPPFLAGS=-I$(HTSDIR)
 HTSDIR=../htslib
 HTSLIB=$(HTSDIR)/libhts.a
-LDLIBS=-lpthread $(HTSLIB) -lz -lm -lbz2 -llzma
+LDLIBS=-lpthread $(HTSLIB) -lz -lm -lbz2 -llzma -lcurl
 
 all: pbwt
 

--- a/pbwt.h
+++ b/pbwt.h
@@ -15,7 +15,7 @@
  * Description: header file for pbwt package
  * Exported functions:
  * HISTORY:
- * Last edited: Jun 16 17:14 2018 (rd)
+ * Last edited: Jul 14 17:14 2019 (djl)
  * added paintSparse function
  * Created: Thu Apr  4 11:02:39 2013 (rd)
  *-------------------------------------------------------------------
@@ -236,8 +236,8 @@ void pbwtLogLikelihoodCopyModel (PBWT *p, double theta, double rho) ;
 
 /* pbwtPaint.c */
 
-void paintAncestryMatrix (PBWT *p, char *fileRoot,int chunksperregion) ;
-void paintAncestryMatrixSparse (PBWT *p, char *fileRoot,int chunksperregion,int cutoff) ;
+void paintAncestryMatrix (PBWT *p, char *fileRoot,int chunksperregion,int ploidy) ;
+void paintAncestryMatrixSparse (PBWT *p, char *fileRoot,int chunksperregion,int ploidy,int cutoff) ;
 
 /* pbwtMerge.c */
 

--- a/pbwt.h
+++ b/pbwt.h
@@ -188,7 +188,7 @@ PBWT *pbwtReadVcfq (FILE *fp) ;	/* reduced VCF style file made by vcf query */
 PBWT *pbwtReadGen (FILE *fp, char *chrom) ;	/* gen file as used by impute2 (unphased) */
 PBWT *pbwtReadHap (FILE *fp, char *chrom) ;	/* hap file as used by impute2 (unphased) */
 PBWT *pbwtReadHapLegend (FILE *fp, FILE *lp, char *chrom) ; /* hap and legend file as used by impute2 (phased) */
-PBWT *pbwtReadPhase (FILE *fp) ; /* Li and Stephens PHASE file */
+PBWT *pbwtReadPhase (FILE *fp, char *chrom) ; /* Li and Stephens PHASE file */
 void pbwtWriteHaplotypes (FILE *fp, PBWT *p) ;
 void pbwtWriteTransposedHaplotypes (PBWT *p, FILE *fp) ;
 void pbwtWriteImputeRef (PBWT *p, char *fileNameRoot) ;

--- a/pbwtIO.c
+++ b/pbwtIO.c
@@ -774,7 +774,7 @@ PBWT *pbwtReadHapLegend (FILE *fp, FILE *lp, char *chrom)
   return p ;
 }
 
-PBWT *pbwtReadPhase (FILE *fp) /* Li and Stephens PHASE format */
+PBWT *pbwtReadPhase (FILE *fp,char *chrom) /* Li and Stephens PHASE format */
 {
   int nhaps=0,nsnps=0,ninds=0;
   int version=2;
@@ -796,7 +796,7 @@ PBWT *pbwtReadPhase (FILE *fp) /* Li and Stephens PHASE format */
   }
   fprintf(logFile,"Reading %i SNPs %i haplotypes and %i individuals from PHASE format version %i\n",nsnps,nhaps,ninds,version);
   PBWT *p = pbwtCreate (nhaps, nsnps) ;
-  p->chrom = strdup ("0") ; /* chromosome number not available from phase files */
+  p->chrom = strdup (chrom) ;
   p->sites = arrayCreate (4096, Site) ;
   int i ; for (i = 0 ; i < p->N ; ++i) {
     tc=fgetword(fp);

--- a/pbwtIO.c
+++ b/pbwtIO.c
@@ -863,7 +863,7 @@ void pbwtWriteTransposedHaplotypes (PBWT *p, FILE *fp)
   
   for (j = 0 ; j < p->M ; ++j)
     { for (i = 0 ; i < p->N ; ++i) 
-	putc (hap[j][i], fp) ;
+	putc (hap[j][i]+'0', fp) ;
       putc ('\n', fp) ; fflush (fp) ;
     }
   

--- a/pbwtMain.c
+++ b/pbwtMain.c
@@ -218,6 +218,7 @@ int main (int argc, char *argv[])
       fprintf (stderr, "  -readHap <file> <chrom>   read impute2 hap file - must set chrom\n") ;
       fprintf (stderr, "  -readHapLegend <hap_file> <legend_file> <chrom>\n") ;
       fprintf (stderr, "                            read impute2 hap and legend file - must set chrom\n") ;
+      fprintf (stderr, "  -readPhaseChr <file> <chr>read Li and Stephens phase file - must set chrom\n") ;
       fprintf (stderr, "  -readPhase <file>         read Li and Stephens phase file\n") ;
       fprintf (stderr, "  -checkpoint <n>           checkpoint every n sites while reading\n") ;
       fprintf (stderr, "  -merge <file> ...         merge two or more pbwt files\n") ;
@@ -325,7 +326,9 @@ int main (int argc, char *argv[])
     else if (!strcmp (argv[0], "-readHapLegend") && argc > 3)
     { if (p) pbwtDestroy (p) ; FOPEN("readHap","r") ; LOPEN("readHap","r") ; p = pbwtReadHapLegend (fp, lp, argv[3]) ; FCLOSE ; LCLOSE ; argc -= 4 ; argv += 4 ; }
     else if (!strcmp (argv[0], "-readPhase") && argc > 1)
-      { if (p) pbwtDestroy (p) ; FOPEN("readPhase","r") ; p = pbwtReadPhase (fp) ; FCLOSE ; argc -= 2 ; argv += 2 ; }
+      { if (p) pbwtDestroy (p) ; FOPEN("readPhase","r") ; p = pbwtReadPhase (fp,"0") ; FCLOSE ; argc -= 2 ; argv += 2 ; }
+    else if (!strcmp (argv[0], "-readPhaseChr") && argc > 2)
+      { if (p) pbwtDestroy (p) ; FOPEN("readPhaseChr","r") ; p = pbwtReadPhase (fp,argv[2]) ; FCLOSE ; argc -= 3 ; argv += 3 ; }
     else if (!strcmp (argv[0], "-write") && argc > 1)
       { FOPEN("write","w") ; pbwtWrite (p, fp) ; FCLOSE ; argc -= 2 ; argv += 2 ; }
     else if (!strcmp (argv[0], "-writeSites") && argc > 1)

--- a/pbwtMain.c
+++ b/pbwtMain.c
@@ -262,7 +262,7 @@ int main (int argc, char *argv[])
       fprintf (stderr, "  -fitAlphaBeta <model>     fit probabilistic model 1..3\n") ;
       fprintf (stderr, "  -llCopyModel <theta> <rho>  log likelihood of Li-Stephens model\n") ;
       fprintf (stderr, "  -paint <fileNameRoot> [n] [p] output painting co-ancestry matrix to fileroot, optionally specififying the number per region and ploidy\n") ;
-      fprintf (stderr, "  -paintSparse <fileNameRoot> [n] [p] output sparse painting to fileroot, optionally specififying the number per region and ploidy\n") ;
+      fprintf (stderr, "  -paintSparse <fileNameRoot> [n] [p] [t] output sparse painting to fileroot, optionally specififying the number per region, ploidy, and threshold for inclusion in the output\n") ;
       fprintf (stderr, "  -pretty <file> <k>        pretty plot at site k\n") ;
       fprintf (stderr, "  -sfs                      print site frequency spectrum (log scale) - also writes sites.freq file\n") ;
       fprintf (stderr, "  -refFreq <file>           read site frequency information into the refFreq field of current sites\n") ;
@@ -448,7 +448,7 @@ int main (int argc, char *argv[])
       { 
 	int npr=100;
 	int ploidy=2;
-	int nargs=1;
+	int nargs=2;
        	if(argc>2) if(argv[2][0] !='-') {
 	    npr=atoi(argv[2]);
 	    ++nargs;
@@ -458,16 +458,28 @@ int main (int argc, char *argv[])
 	    ++nargs;
 	  }
 	paintAncestryMatrix (p, argv[1],npr,ploidy) ; 
-	printf("Args %i\n",nargs);
 	argc-=nargs;argv+=nargs;
       }
     else if (!strcmp (argv[0], "-paintSparse") && argc > 1)
       { 
 	int npr=100;
 	int ploidy=2;
-       	if(argc>2) if(argv[2][0] !='-') npr=atoi(argv[2]);
-	paintAncestryMatrixSparse (p, argv[1],npr,ploidy,0) ; argc -= 2 ; argv += 2 ; 
-       	if(argc>0) if(argv[0][0] !='-') {--argc;++argv; }
+	int nargs=2;
+	double thresh=0;
+       	if(argc>2) if(argv[2][0] !='-') {
+	    npr=atoi(argv[2]);
+	    ++nargs;
+	  }
+       	if(argc>3) if(argv[3][0] !='-') {
+	    ploidy=atoi(argv[3]);
+	    ++nargs;
+	  }
+       	if(argc>4) if(argv[3][0] !='-') {
+	    thresh=atof(argv[4]);
+	    ++nargs;
+	  }
+	paintAncestryMatrixSparse (p, argv[1],npr,ploidy,thresh) ; 
+	argc-=nargs;argv+=nargs;
       }
     else if (!strcmp (argv[0], "-play"))
       { p = playGround (p) ; argc -= 1 ; argv += 1 ; }

--- a/pbwtMain.c
+++ b/pbwtMain.c
@@ -349,7 +349,7 @@ int main (int argc, char *argv[])
     else if (!strcmp (argv[0], "-writePhase") && argc > 1)
       { pbwtWritePhase (p,argv[1]) ; argc -= 2 ; argv += 2 ; }
     else if (!strcmp (argv[0], "-writeTransposedHaplotypes") && argc > 1)
-      { FOPEN("writeTransposedHaplotypes",argv[0]) ; pbwtWriteTransposedHaplotypes (p, fp) ; argc -= 2 ; argv += 2 ; }
+      { FOPEN("writeTransposedHaplotypes","w") ; pbwtWriteTransposedHaplotypes (p, fp) ; argc -= 2 ; argv += 2 ; }
     else if (!strcmp (argv[0], "-referenceFasta") && argc > 1)
       { referenceFasta = strdup(argv[1]) ; argc -= 2 ; argv += 2 ; }
     else if (!strcmp (argv[0], "-writeVcf") && argc > 1)

--- a/pbwtMain.c
+++ b/pbwtMain.c
@@ -261,8 +261,8 @@ int main (int argc, char *argv[])
       fprintf (stderr, "  -imputeMissing            impute data marked as missing\n") ;
       fprintf (stderr, "  -fitAlphaBeta <model>     fit probabilistic model 1..3\n") ;
       fprintf (stderr, "  -llCopyModel <theta> <rho>  log likelihood of Li-Stephens model\n") ;
-      fprintf (stderr, "  -paint <fileNameRoot> [n] output painting co-ancestry matrix to fileroot, optionally specififying the number per region\n") ;
-      fprintf (stderr, "  -paintSparse <fileNameRoot> [n] output sparse painting to fileroot, optionally specififying the number per region\n") ;
+      fprintf (stderr, "  -paint <fileNameRoot> [n] [p] output painting co-ancestry matrix to fileroot, optionally specififying the number per region and ploidy\n") ;
+      fprintf (stderr, "  -paintSparse <fileNameRoot> [n] [p] output sparse painting to fileroot, optionally specififying the number per region and ploidy\n") ;
       fprintf (stderr, "  -pretty <file> <k>        pretty plot at site k\n") ;
       fprintf (stderr, "  -sfs                      print site frequency spectrum (log scale) - also writes sites.freq file\n") ;
       fprintf (stderr, "  -refFreq <file>           read site frequency information into the refFreq field of current sites\n") ;
@@ -447,15 +447,26 @@ int main (int argc, char *argv[])
     else if (!strcmp (argv[0], "-paint") && argc > 1)
       { 
 	int npr=100;
-       	if(argc>2) if(argv[2][0] !='-') npr=atoi(argv[2]);
-	paintAncestryMatrix (p, argv[1],npr) ; argc -= 2 ; argv += 2 ; 
-       	if(argc>0) if(argv[0][0] !='-') {--argc;++argv; }
+	int ploidy=2;
+	int nargs=1;
+       	if(argc>2) if(argv[2][0] !='-') {
+	    npr=atoi(argv[2]);
+	    ++nargs;
+	  }
+       	if(argc>3) if(argv[3][0] !='-') {
+	    ploidy=atoi(argv[3]);
+	    ++nargs;
+	  }
+	paintAncestryMatrix (p, argv[1],npr,ploidy) ; 
+	printf("Args %i\n",nargs);
+	argc-=nargs;argv+=nargs;
       }
     else if (!strcmp (argv[0], "-paintSparse") && argc > 1)
       { 
 	int npr=100;
+	int ploidy=2;
        	if(argc>2) if(argv[2][0] !='-') npr=atoi(argv[2]);
-	paintAncestryMatrixSparse (p, argv[1],npr,0) ; argc -= 2 ; argv += 2 ; 
+	paintAncestryMatrixSparse (p, argv[1],npr,ploidy,0) ; argc -= 2 ; argv += 2 ; 
        	if(argc>0) if(argv[0][0] !='-') {--argc;++argv; }
       }
     else if (!strcmp (argv[0], "-play"))

--- a/pbwtPaint.c
+++ b/pbwtPaint.c
@@ -15,7 +15,7 @@
  * Description: tools for chromosome painting as in ChromoPainter, FineStructure etc.
  * Exported functions:
  * HISTORY:
- * Last edited: Jul  4 23:55 2017 (rd)
+ * Last edited: Jul 14 8:33:00 2019 (djl)
  * Created: Tue Apr  1 11:34:41 2014 (rd)
  *-------------------------------------------------------------------
  */
@@ -53,9 +53,8 @@ static inline void printAll(int ii,int Ninds,
   gzprintf (fr,"IND%i %.2f\n",ii+1, nregions) ; 
 }
 
-void paintAncestryMatrix (PBWT *p, char* fileRoot,int chunksperregion)
+void paintAncestryMatrix (PBWT *p, char* fileRoot,int chunksperregion,int ploidy)
 {
-  int ploidy=2;
   int Ninds=p->M/ploidy;
   double **totlengths = 0 ;
   double **counts = 0 ;
@@ -169,10 +168,9 @@ void paintAncestryMatrix (PBWT *p, char* fileRoot,int chunksperregion)
   free (counts) ; free (counts2) ; free (counts3) ; free (totCounts) ; free (nregions); free(totlengths);
 }
 
-void paintAncestryMatrixSparse (PBWT *p, char* fileRoot,int chunksperregion,int cutoff)
+void paintAncestryMatrixSparse (PBWT *p, char* fileRoot,int chunksperregion,int ploidy,int cutoff)
 {
   int i, j, k ;
-  int ploidy=2;
   int Ninds=p->M/ploidy;
   int *map_indhap = mycalloc (p->M,int);
   for (i = 0 ; i < p->M ; ++i) map_indhap[i]=i/ploidy;


### PR DESCRIPTION
The tidying up of the code for -writeTransposedHaplotypes had a minor bug which broke -writePhase. This is now fixed. Compare with 

cd test; ../pbwt -readVcfGT read.vcf -writeTransposedHaplotypes read.thap
(which cannot open file in current revision)
cd test; ../pbwt -readVcfGT read.vcf -writePhase read.phase
(which creates binary-like output, 0 and 1 ascii characters instead of '0' and '1'.)
