### PR TITLE
revised typos for subsampling individuals and writeTransposedHaplotypes

### DIFF
--- a/pbwtMain.c
+++ b/pbwtMain.c
@@ -231,7 +231,7 @@ int main (int argc, char *argv[])
       fprintf (stderr, "  -writeImputeRef <rootname> write .imputeHaps and .imputeLegend\n") ;
       fprintf (stderr, "  -writeImputeHapsG <file>  write haplotype file for IMPUTE -known_haps_g\n") ;
       fprintf (stderr, "  -writePhase <file>        write FineSTRUCTURE/ChromoPainter input format (Impute/ShapeIT output format) phase file\n") ;
-      fprintf (stderr, "  -writeTransposeHaplotypes <file>    write transposed haplotype file (one hap per row); '-' for stdout\n") ;
+      fprintf (stderr, "  -writeTransposedHaplotypes <file>    write transposed haplotype file (one hap per row); '-' for stdout\n") ;
       fprintf (stderr, "  -haps <file>              write haplotype file; '-' for stdout\n") ;
       fprintf (stderr, "  -writeGen <file>          write impute2 gen file; '-' for stdout\n") ;
       fprintf (stderr, "  -writeVcf|-writeVcfGz|-writeBcf|-writeBcfGz <file>\n") ;
@@ -364,7 +364,7 @@ int main (int argc, char *argv[])
       { nCheckPoint = atoi (argv[1]) ; argc -= 2 ; argv += 2 ; }
     else if (!strcmp (argv[0], "-subsample") && argc > 2)
       { p = pbwtSubSampleInterval (p, atoi(argv[1]), atoi(argv[2])) ; argc -= 3 ; argv += 3 ; }
-    else if (!strcmp (argv[0], "-selectSamples") && argc > 2)
+    else if (!strcmp (argv[0], "-selectSamples") && argc > 1)
       { FOPEN("selectSamples","r") ; p = pbwtSelectSamples (p, fp) ; argc -= 2 ; argv += 2 ; }
     else if (!strcmp (argv[0], "-subsites") && argc > 2)
       { p = pbwtSubSites (p, atof(argv[1]), atof(argv[2])) ; argc -= 3 ; argv += 3 ; }


### PR DESCRIPTION
Just a simple change to a flag and argument number for the `-selectSamples` flag 
