### PR TITLE
fix typo in help (writeTranspose[d]Haplotypes)

### DIFF
--- a/pbwtMain.c
+++ b/pbwtMain.c
@@ -232,7 +232,7 @@ int main (int argc, char *argv[])
       fprintf (stderr, "  -writeImputeRef <rootname> write .imputeHaps and .imputeLegend\n") ;
       fprintf (stderr, "  -writeImputeHapsG <file>  write haplotype file for IMPUTE -known_haps_g\n") ;
       fprintf (stderr, "  -writePhase <file>        write FineSTRUCTURE/ChromoPainter input format (Impute/ShapeIT output format) phase file\n") ;
-      fprintf (stderr, "  -writeTransposeHaplotypes <file>    write transposed haplotype file (one hap per row); '-' for stdout\n") ;
+      fprintf (stderr, "  -writeTransposedHaplotypes <file>    write transposed haplotype file (one hap per row); '-' for stdout\n") ;
       fprintf (stderr, "  -haps <file>              write haplotype file; '-' for stdout\n") ;
       fprintf (stderr, "  -writeGen <file>          write impute2 gen file; '-' for stdout\n") ;
       fprintf (stderr, "  -writeVcf|-writeVcfGz|-writeBcf|-writeBcfGz <file>\n") ;


### PR DESCRIPTION
This PR fixes the `-writeTransposedHaplotypes` help message