### PR TITLE
PBWT -paint bugfixes and documentation

### DIFF
--- a/pbwt.h
+++ b/pbwt.h
@@ -236,7 +236,7 @@ void pbwtLogLikelihoodCopyModel (PBWT *p, double theta, double rho) ;
 
 /* pbwtPaint.c */
 
-void paintAncestryMatrix (PBWT *p, char *fileRoot,int chunksperregion,int ploidy) ;
+void paintAncestryMatrix (PBWT *p, char *fileRoot,int chunksperregion,int ploidy,int outputlocal) ;
 void paintAncestryMatrixSparse (PBWT *p, char *fileRoot,int chunksperregion,int ploidy,int cutoff) ;
 
 /* pbwtMerge.c */

--- a/pbwtMain.c
+++ b/pbwtMain.c
@@ -261,8 +261,8 @@ int main (int argc, char *argv[])
       fprintf (stderr, "  -imputeMissing            impute data marked as missing\n") ;
       fprintf (stderr, "  -fitAlphaBeta <model>     fit probabilistic model 1..3\n") ;
       fprintf (stderr, "  -llCopyModel <theta> <rho>  log likelihood of Li-Stephens model\n") ;
-      fprintf (stderr, "  -paint <fileNameRoot> [n] [p] output painting co-ancestry matrix to fileroot, optionally specififying the number per region and ploidy\n") ;
-      fprintf (stderr, "  -paintSparse <fileNameRoot> [n] [p] [t] output sparse painting to fileroot, optionally specififying the number per region, ploidy, and threshold for inclusion in the output\n") ;
+      fprintf (stderr, "  -paint <fileNameRoot> [n=100] [p=2] output painting co-ancestry matrix to fileroot, optionally specififying the number per region and ploidy\n") ;
+      fprintf (stderr, "  -paintSparse <fileNameRoot> [n=100] [p=2] [t=0] output sparse painting to fileroot, optionally specififying the number per region, ploidy, and threshold for inclusion in the output\n") ;
       fprintf (stderr, "  -pretty <file> <k>        pretty plot at site k\n") ;
       fprintf (stderr, "  -sfs                      print site frequency spectrum (log scale) - also writes sites.freq file\n") ;
       fprintf (stderr, "  -refFreq <file>           read site frequency information into the refFreq field of current sites\n") ;

--- a/pbwtMain.c
+++ b/pbwtMain.c
@@ -261,7 +261,7 @@ int main (int argc, char *argv[])
       fprintf (stderr, "  -imputeMissing            impute data marked as missing\n") ;
       fprintf (stderr, "  -fitAlphaBeta <model>     fit probabilistic model 1..3\n") ;
       fprintf (stderr, "  -llCopyModel <theta> <rho>  log likelihood of Li-Stephens model\n") ;
-      fprintf (stderr, "  -paint <fileNameRoot> [n=100] [p=2] output painting co-ancestry matrix to fileroot, optionally specififying the number per region and ploidy\n") ;
+      fprintf (stderr, "  -paint <fileNameRoot> [n=100] [p=2] [l=0] output painting co-ancestry matrix to fileroot, optionally specififying the number per region, ploidy, and whether to output local ancestry\n") ;
       fprintf (stderr, "  -paintSparse <fileNameRoot> [n=100] [p=2] [t=0] output sparse painting to fileroot, optionally specififying the number per region, ploidy, and threshold for inclusion in the output\n") ;
       fprintf (stderr, "  -pretty <file> <k>        pretty plot at site k\n") ;
       fprintf (stderr, "  -sfs                      print site frequency spectrum (log scale) - also writes sites.freq file\n") ;
@@ -448,6 +448,7 @@ int main (int argc, char *argv[])
       { 
 	int npr=100;
 	int ploidy=2;
+	int outputlocal=0;
 	int nargs=2;
        	if(argc>2) if(argv[2][0] !='-') {
 	    npr=atoi(argv[2]);
@@ -457,7 +458,11 @@ int main (int argc, char *argv[])
 	    ploidy=atoi(argv[3]);
 	    ++nargs;
 	  }
-	paintAncestryMatrix (p, argv[1],npr,ploidy) ; 
+       	if(argc>4) if(argv[4][0] !='-') {
+	    outputlocal=atoi(argv[4]);
+	    ++nargs;
+	  }
+	paintAncestryMatrix (p, argv[1],npr,ploidy,outputlocal); 
 	argc-=nargs;argv+=nargs;
       }
     else if (!strcmp (argv[0], "-paintSparse") && argc > 1)

--- a/pbwtPaint.c
+++ b/pbwtPaint.c
@@ -97,6 +97,7 @@ void paintAncestryMatrix (PBWT *p, char* fileRoot,int chunksperregion,int ploidy
 	  while (m1->end <= k && m1 < mStop)
 	    { if ((n1 % chunksperregion)==0)
 		{ int jj ; for (jj = 0 ; jj < Ninds ; ++jj) {
+		    if(map_indhap[i]==jj) continue; // skip match to self
 		    counts2[map_indhap[i]][jj] += partCounts[jj]*partCounts[jj] ;
 		    counts3[map_indhap[i]][jj] += partCounts[jj] ;
 		  }
@@ -105,10 +106,11 @@ void paintAncestryMatrix (PBWT *p, char* fileRoot,int chunksperregion,int ploidy
 		}
 	      ++m1 ; ++n1 ;
 	    }
-	  for (m = m1 ; m->start < k && m <= mStop ; ++m) 
+	  for (m = m1 ; m->start < k && m <= mStop ; ++m)  if(map_indhap[i]!=map_indhap[m->j])  // skip match to self
 	    sum += (k - m->start) * (m->end - k) ;
 	  if (sum)
 	    for (m = m1 ; m->start < k && m <= mStop ; ++m) {
+	      if(map_indhap[i]==map_indhap[m->j]) continue; // skip match to self
 	      totlengths[map_indhap[i]][map_indhap[m->j]] += (k - m->start) * (m->end - k) / sum;
  	      double thiscount=(k - m->start) * (m->end - k) / sum/(m->end - m->start);
 	      counts[map_indhap[i]][map_indhap[m->j]] += thiscount;
@@ -199,7 +201,7 @@ void paintAncestryMatrixSparse (PBWT *p, char* fileRoot,int chunksperregion,int 
   double *partCounts = myalloc (Ninds, double) ; 
 
   /* now weight per site based on distance from ends */
-  /// i =1 .. M is each SNP
+  /// i =1 .. M is each haplotype
   for (i = 0 ; i < p->M ; ++i)
     {
       //      printf("Processing Individual %i in haplotype %i\n",i/ploidy,i);
@@ -223,8 +225,10 @@ void paintAncestryMatrixSparse (PBWT *p, char* fileRoot,int chunksperregion,int 
       for (k = 1 ; k < p->N ; k++) 
 	{ double sum = 0 ;
 	  while (m1->end <= k && m1 < mStop)
-	    { if ((n1 % chunksperregion)==0) { 
+	    {
+	      if ((n1 % chunksperregion)==0) { 
 		int jj ; for (jj = 0 ; jj < Ninds ; ++jj) {
+		    if(map_indhap[i]==jj) continue; // skip match to self
 		  if(partCounts[jj]){
 		    t_counts2[jj] += partCounts[jj]*partCounts[jj] ;
 		    t_counts3[jj] += partCounts[jj] ;
@@ -237,9 +241,11 @@ void paintAncestryMatrixSparse (PBWT *p, char* fileRoot,int chunksperregion,int 
 	    }
 	  // for every individual who has a sufficiently long match
 	  for (m = m1 ; m->start < k && m <= mStop ; ++m) 
+	      if(map_indhap[i]!=map_indhap[m->j]) // skip match to self
 	    sum += (k - m->start) * (m->end - k) ;
 	  if (sum)
 	    for (m = m1 ; m->start < k && m <= mStop ; ++m) {
+	      if(i==map_indhap[m->j]) continue; // skip match to self
 	      double thislengths = (k - m->start) * (m->end - k) / sum;
  	      double thiscount=(k - m->start) * (m->end - k) / sum/(m->end - m->start);
 

--- a/pbwtPaint.c
+++ b/pbwtPaint.c
@@ -268,11 +268,11 @@ void paintAncestryMatrixSparse (PBWT *p, char* fileRoot,int chunksperregion,int 
 	    }
 	  // for every individual who has a sufficiently long match
 	  for (m = m1 ; m->start < k && m <= mStop ; ++m) 
-	      if(map_indhap[i]!=map_indhap[m->j]) // skip match to self
-	    sum += (k - m->start) * (m->end - k) ;
+	    if((map_indhap[i]!=map_indhap[m->j])&&(m->end-m->start>cutoff)) // skip match to self
+	      sum += (k - m->start) * (m->end - k) ;
 	  if (sum)
 	    for (m = m1 ; m->start < k && m <= mStop ; ++m) {
-	      if(i==map_indhap[m->j]) continue; // skip match to self
+	      if((map_indhap[i]==map_indhap[m->j])||(m->end-m->start<=cutoff)) continue;// skip match to self
 	      double thislengths = (k - m->start) * (m->end - k) / sum;
  	      double thiscount=(k - m->start) * (m->end - k) / sum/(m->end - m->start);
 

--- a/pbwtPaint.c
+++ b/pbwtPaint.c
@@ -92,7 +92,7 @@ void paintAncestryMatrix (PBWT *p, char* fileRoot,int chunksperregion,int ploidy
     flp = fopenTag (fileRoot, "localancestry.out", "w") ;
     localsum = myalloc (Ninds, double*) ;
     for (i = 0 ; i < Ninds ; ++i) localsum[i] = mycalloc (p->N, double) ;
-    fprintf (flp,"pos ");
+    fprintf (flp,"pos");
     for (i = 0 ; i < Ninds ; ++i) fprintf (flp," IND%i",i+1);
     fprintf (flp,"\n");
   }
@@ -109,7 +109,7 @@ void paintAncestryMatrix (PBWT *p, char* fileRoot,int chunksperregion,int ploidy
       int n1 = 1 ;		/* so don't have an empty chunk to start with! */
       MatchSegment *mStop = arrp(maxMatch[i], arrayMax(maxMatch[i])-1, MatchSegment) ;
       memset (partCounts, 0, sizeof(double)*Ninds) ;
-      for (k = 0 ; k < p->N ; k++) // k is the SITE NUMBER
+      for (k = 1 ; k < p->N ; k++) // k is the SITE NUMBER
 	{ double sum = 0 ;
 	  while (m1->end <= k && m1 < mStop)
 	    { if ((n1 % chunksperregion)==0)
@@ -138,7 +138,7 @@ void paintAncestryMatrix (PBWT *p, char* fileRoot,int chunksperregion,int ploidy
       if(outputlocal) {
 	fprintf (flp,"HAP %i IND%i\n",i+1,map_indhap[i]+1);
 	for (k = p->N-1 ; k >=0 ; --k) {
-	  fprintf(flp,"%i ",arrayp(p->sites,k,Site)->x);
+	  fprintf(flp,"%i",arrayp(p->sites,k,Site)->x);
 	   for(j=0; j<Ninds;++j) fprintf (flp," %0.3f",localsum[j][k]);
 	  fprintf (flp,"\n");
 	}
@@ -249,7 +249,7 @@ void paintAncestryMatrixSparse (PBWT *p, char* fileRoot,int chunksperregion,int 
 	memset (t_totlengths, 0, sizeof(double)*Ninds) ;
       }
 
-      for (k = 0 ; k < p->N ; k++) 
+      for (k = 1 ; k < p->N ; k++)
 	{ double sum = 0 ;
 	  while (m1->end <= k && m1 < mStop)
 	    {

--- a/pbwtPaint.c
+++ b/pbwtPaint.c
@@ -44,13 +44,13 @@ static inline void printAll(int ii,int Ninds,
 			    gzFile fc,gzFile fc2,gzFile fc3,gzFile fl,gzFile fr){
   int jj ; for (jj = 0 ; jj < Ninds ; ++jj) {
     if(t_counts[jj]){
-      gzprintf (fc, "IND%i IND%i %.4f\n", ii+1,jj+1,t_counts[jj]) ; 
-      gzprintf (fl, "IND%i IND%i %.4f\n", ii+1,jj+1,t_totlengths[jj]) ; 
-      gzprintf (fc2,"IND%i IND%i %.4f\n", ii+1,jj+1,t_counts2[jj]) ; 
-      gzprintf (fc3,"IND%i IND%i %.4f\n", ii+1,jj+1,t_counts3[jj]) ; 
+      gzprintf (fc, "%i %i %.4f\n", ii+1,jj+1,t_counts[jj]) ; 
+      gzprintf (fl, "%i %i %.4f\n", ii+1,jj+1,t_totlengths[jj]) ; 
+      gzprintf (fc2,"%i %i %.4f\n", ii+1,jj+1,t_counts2[jj]) ; 
+      gzprintf (fc3,"%i %i %.4f\n", ii+1,jj+1,t_counts3[jj]) ; 
     }
   }
-  gzprintf (fr,"IND%i %.2f\n",ii+1, nregions) ; 
+  gzprintf (fr,"%i %.2f\n",ii+1, nregions) ; 
 }
 
 void paintAncestryMatrix (PBWT *p, char* fileRoot,int chunksperregion,int ploidy,int outputlocal)


### PR DESCRIPTION
Fixed some minor issues with the pbwt -paint and -paintSparse commands:

1. There was a bug causing the first SNP to be mis-painted
2. Added an option to output local ancestry (though this is low accuracy)
3. Fixed the painting to account for diploidy - so no more self-copying of diploid individuals
4. The help provides default parameters