### PR TITLE
Add gzipped output for pbwt-paint, sample name labels to coancestry painting and automatically compile htslib dependencies in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CFLAGS= -g -O3
 CPPFLAGS=-I$(HTSDIR)
 HTSDIR=../htslib
 HTSLIB=$(HTSDIR)/libhts.a
-LDLIBS=-lpthread $(HTSLIB) -lz -lm -lbz2 -llzma -lcurl
+LDLIBS=-lpthread $(HTSLIB) -lz -lm -lbz2 -llzma -lcurl -lcrypto
 
 all: pbwt
 


### PR DESCRIPTION
Hi, just a few changes to pbwtPaint that I found useful for myself. 

1. Gzipping the outputs of -paint 
2. Including the sample names from the vcf 
3. Automatically cloning and making the htslib dependency during pbwt compilation 

