### PR TITLE
Fix formatting of installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,17 @@ Installation instructions
 ------------------------
 Download htslib from https://github.com/samtools/htslib, and compile it
 
-   git clone https://github.com/samtools/htslib
-   cd htslib
-   make
-   cd ..
+    git clone https://github.com/samtools/htslib
+    cd htslib
+    git submodule update --init --recursive  # Download htscodecs submodule
+    make
+    cd ..
 
 Download and make pbwt
 
-   git clone https://github.com/richarddurbin/pbwt
-   cd pbwt
-   make
+    git clone https://github.com/richarddurbin/pbwt
+    cd pbwt
+    make
 
 Brief usage instructions
 ------------------------


### PR DESCRIPTION
The Markdown installation instructions weren't rendering properly [here](https://github.com/richarddurbin/pbwt/blob/29901a7/README.md#installation-instructions). Each line just needed an extra space.
I also added the `htscodecs` step.
